### PR TITLE
Add progfest info 2025

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
                                 
                             </p>
                             <p class="text-whitespace-top-med">
-                                This year's lineup includes a full performance of Pink Floyd's&nbsp;<span class="italics">Dark Side of the Moon</span>, a tribute to Kansas, and  
+                                This year's lineup includes a full performance of Pink Floyd's&nbsp;<span class="italics">The Dark Side of the Moon</span>,&nbsp;a tribute to&nbsp<span class="italics">Kansas</span>, and  
                                 original sets from local artists like&nbsp;<span class="italics">Jamie Krutz</span>,&nbsp;<span class="italics">Dave Fritzler and Laura Wade Quam</span>,&nbsp;<span class="italics">G3P</span>,&nbsp;<span class="italics">Renegade Royalty</span>,&nbsp;and&nbsp;<span class="italics">MC2 Project</span>.
                             </p>
                            

--- a/index.html
+++ b/index.html
@@ -99,6 +99,172 @@
                 </div>
             </section>
         </div>
+
+        <div class="main-page-wrapper bg-clr-dark">
+            <section class="section-wrapper-two">
+                <div class="section-container">
+                   
+                        <h3 class="section-title">PROGFEST 2025</h3>
+                        <a class="progfest-ticket-button" href="https://nissis.com/events/progfest-2025/" target="_blank">Purchase Tickets Here</a>
+                
+                    <div class="progFest-grid">
+                        <div class="progFest-grid--left" >
+                            <img src="./images/progfest-2025-poster.jpg" alt="">
+                        </div>
+                        <div class="progFest-grid--right">
+                            <p>ProgFest annually showcases top-notch musicians from Colorado, featuring a dynamic mix of classic and original prog rock, art rock, jazz fusion, and more. 
+                                
+                            </p>
+                            <p class="text-whitespace-top-med">
+                                This year's lineup includes a full performance of Pink Floyd's&nbsp;<span class="italics">Dark Side of the Moon</span>, a tribute to Kansas, and  
+                                original sets from local artists like&nbsp;<span class="italics">Jamie Krutz</span>,&nbsp;<span class="italics">Dave Fritzler and Laura Wade Quam</span>,&nbsp;<span class="italics">G3P</span>,&nbsp;<span class="italics">Renegade Royalty</span>,&nbsp;and&nbsp;<span class="italics">MC2 Project</span>.
+                            </p>
+                           
+                            <div class="progFest-essentials-container">
+                                <h4>Progfest Essentials</h4>
+                                <div class="progFest-details-container">
+                                    <div class="progFest-text-grid">
+                                        <h5>DATE</h5>
+                                        <p>Sunday February 16th, 2024</p>
+                                    </div>
+                                    <div class="progFest-text-grid">
+                                        <h5>TIME</h5>
+                                        <div>
+                                            <p>Doors Open: 3:00pm</p>
+                                            <p>Show Starts: 4:00pm</p>
+                                        </div>
+                                    </div>
+                                    <div class="progFest-text-grid">
+                                        <h5>PLACE</h5>
+                                        <div>
+                                            <p>Nissi's</p>
+                                            <p>Lafayette, CO</p>
+                                        </div>
+                                    </div>
+                                    <div class="progFest-text-grid">
+                                        <h5>TICKETS</h5>
+                                        <div>
+                                            <p>$15 Advanced / $20 Day of show</p>
+                                            <p>Tickets can be purchased at <a href="https://nissis.com/events/progfest-2025/" target="_blank">Nissis.com</a></p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="progFest-essentials-container">
+                                <h4>Chronology</h4>
+                                <div class="progFest-details-container">
+                                    <div class="progFest-text-grid">
+                                        <h5>3:00</h5>
+                                        <p>Doors Open</p>
+                                    </div>
+                                    <div class="progFest-text-grid">
+                                        <h5>4:00</h5>
+                                        <p>Opening Remarks</p>
+                                    </div>
+                                    <div class="progFest-text-grid">
+                                        <h5>4:05</h5>
+                                        <p>
+                                            <a class="schedule-band-link" href="https://monstradamus.bravesites.com/" target="_blank">Renegade Royalty</a>
+                                        </p>
+
+                                    </div>
+                                    <div class="progFest-text-grid">
+                                        <h5>4:40</h5>
+                                        <p>
+                                            <a class="schedule-band-link" href="https://g3pband.com/" target="_blank">G3P</a>
+                                        </p>
+                                    </div>
+                                    <div class="progFest-text-grid">
+                                        <h5>5:15</h5>
+                                        <p>
+                                            <a class="schedule-band-link" href="https://www.themc2project.com" target="_blank">MC2 Project</a>
+                                        </p>
+                                    </div>
+                                    <div class="progFest-text-grid">
+                                        <h5>5:50</h5>
+                                        <p>Dave & Laura's Prog Explosion</p>
+                                    </div>
+                                    <div class="progFest-text-grid">
+                                        <h5>6:25</h5>
+                                        <p>
+                                            <a class="schedule-band-link" href="https://www.jamiekrutz.com/" target="_blank">Jamie Krutz and Friends</a>
+                                        </p>
+                                    </div>
+                                    <div class="progFest-text-grid">
+                                        <h5>7:00</h5>
+                                        <p>Mike Masse and the Kansas Project</p>
+                                    </div>
+                                    <div class="progFest-text-grid">
+                                        <h5>7:35</h5>
+                                        <p>The CARS All Stars present Pink Floyd's <span class="italics">The Dark Side of the Moon</span></p>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="progFest-essentials-container">
+                                <h4>Featured Festival Bands</h4>
+                                <div class="progFest-details-container"></div>
+                                <div class="progFest-text-grid--performers">
+                                    <h5>
+                                        <a class="schedule-band-link" href="https://monstradamus.bravesites.com/" target="_blank">Renegade Royalty</a>
+                                    </h5>
+                                    <p>Epic Original Prog! Featuring Jon (bass/vox), Giovanni (gtr/lead vox), Armani (drums), and Jackson (Moog)</p>
+                                </div>
+                                <div class="progFest-text-grid--performers">
+                                    <h5>
+                                        <a class="schedule-band-link" href="https://g3pband.com/home" target="_blank">GP3</a>
+                                    </h5>
+                                    <p>G3P is a Denver-based progressive rock power trio, blending simple grooves with intricate multi-meter compositions and lyrics that range from serious to quirky.</p>
+                                </div>
+                                <div class="progFest-text-grid--performers">
+                                    <h5>
+                                        <a class="schedule-band-link" href="https://www.themc2project.com" target="_blank">The MC2 Project</a>
+                                    </h5>
+                                    <p>Instrumental prog rock influenced by hard rock, jazz and classic rock.</p>
+                                </div>
+          
+                                <div class="progFest-text-grid--performers">
+                                    <h5>Dave & Laura's Prog Explosion</h5>
+                                    <p>
+                                        A mix of instrumental and vocal music, including some ProgFest debuts, performed by&nbsp;<span class="italics">Dave Fritzler</span>&nbsp;(guitar), 
+                                        &nbsp;<span class="italics">Laura Quam</span>&nbsp;(violin, vocals),&nbsp;<span class="italics">Gretchen Eick</span>&nbsp;(vocals, guitar),&nbsp;<span class="italics">Jamie Krutz</span>&nbsp;(keyboards),&nbsp;<span class="italics">Mike Mellenger</span>&nbsp;(keyboards),
+                                        &nbsp;<span class="italics">Lane Patterson</span>&nbsp;(bass),&nbsp;and&nbsp;<span class="italics">Garry Stafford</span>&nbsp;(drums).
+                                    </p>
+                                </div>
+                                <div class="progFest-text-grid--performers">
+                                    <h5>
+                                        <a class="schedule-band-link" href="https://www.jamiekrutz.com/" target="_blank">Jamie Krutz & Friends</a>
+                                    </h5>
+                                    <div class="progfest-multi-paragraph">
+                                        <p>
+                                            Original Art/Prog Rock, by singer/songwriter/multi-instrumentalist&nbsp;<span class="italics">Jamie Krutz</span>&nbsp;.
+                                        </p>
+                                        <p>
+                                            With&nbsp;<span class="italics">Laura Quam</span>&nbsp;(violin, vocals),&nbsp;<span class="italics">Todd Caron</span>&nbsp;(guitar),&nbsp;<span class="italics">Gretchen Eick</span>&nbsp;(vocals, guitar, flute),&nbsp;<span class="italics">Paul McLean</span>&nbsp;(keyboards),&nbsp;<span class="italics">Todd Labo</span>&nbsp;(bass), and&nbsp;<span class="italics">Jamie McGregor</span>&nbsp;(drums). 
+                                        </p>
+                                    </div>
+                                </div>
+                                <div class="progFest-text-grid--performers">
+                                    <h5>
+                                        Mike Masse and the Kansas Project
+                                    </h5>
+                                    <p>
+                                       Kansas Tribute!
+                                    </p>
+                                </div>
+                                <div class="progFest-text-grid--performers">
+                                    <h5>
+                                        The CARS All Stars present Pink Floyd's&nbsp;<span class="italics">The Dark Side of the Moon</span>
+                                    </h5>
+                                    <p>
+                                        We're bringing the entire album to life with a full performance of this timeless classic that explores themes of conflict, greed, time, death and mental illness.
+                                    </p>
+                                </div>
+                            </div> 
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </div>
         <div class="main-page-wrapper bg-clr-dark">
             <div class="listening-overlay"></div>
             <img class="background-image-one" src="./images/console.jpg" alt="">

--- a/meetings.html
+++ b/meetings.html
@@ -63,8 +63,8 @@
     <main class="holiday-meetings-bkgd-100">
         <div class="holiday-relative">
           
-                <img class="church-background-image" src="./images/pages/meetings/church-background.jpg" alt="">
-                <div class="church-background-overlay"></div>
+            <img class="church-background-image" src="./images/pages/meetings/church-background.jpg" alt="">
+            <div class="church-background-overlay"></div>
         
         <!-- <div class="meetings-bkgd-100">
             <div class="meetings-section-container">
@@ -171,12 +171,10 @@
             <div class="meetings-section-container">
                 <div class="meetings-images-container">
                     <div class="meetings-img-one--container">
-                        <!-- <img class="meetings-img-one" src="./images/pages/meetings/turntable.png" alt="turntable"> -->
-                        <img class="meetings-img-one" src="./images/pages/meetings/holiday-street-snow.jpg" alt="holiday street">
+                        <img class="meetings-img-one" src="./images/pages/meetings/turntable.png" alt="turntable">
                     </div>
                     <div class="meetings-img-two--container">
-                        <!-- <img  class="meetings-img-two" src="./images/pages/meetings/kidSinging.png" alt="">  -->
-                        <img  class="meetings-img-two" src="./images/pages/meetings/holiday-street-angel.jpg" alt="holiday street"> 
+                        <img  class="meetings-img-two" src="./images/pages/meetings/kidSinging.png" alt=""> 
                     </div>
                 </div>
             </div>

--- a/styles/mainStyles.css
+++ b/styles/mainStyles.css
@@ -13,8 +13,8 @@
     --clr-gray:  #21272f;
     --clr-main: #c59f63;
     --clr-main-light-text: #a58654;
-    /* --clr-accent-one: #C563BA; */
-    --clr-accent-one: #8EA7C8;
+    --clr-accent-one: #C563BA;
+    /* --clr-accent-one: #8EA7C8; */
 
     /* --clr-accent-one: #ca48bb; */
     --pg-margin-full: 4rem;
@@ -77,6 +77,10 @@ a {
 
 .bg-clr-black {
     background: var(--clr-black);
+}
+
+.text-whitespace-top-med {
+    padding-top: 0.5rem;
 }
 
 .main-page {
@@ -205,6 +209,10 @@ a {
     text-decoration: underline;
     color: var(--clr-text-100) !important;
     word-break: break-word;
+}
+
+.schedule-band-link:hover {
+    color: var(--clr-main) !important;
 }
 
 .progfest-ticket-button {
@@ -1340,6 +1348,12 @@ a {
  /* End member spotlight section classes */
 
  /* Progfest classes */
+
+ .progfest-multi-paragraph {
+    display: flex;
+    flex-direction: column;
+    row-gap: 0.5rem;
+ }
  .progFest-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
@@ -1433,8 +1447,12 @@ a {
  .progFest-text-grid a {
     color: var(--clr-main);
  }
+
+ .progFest-text-grid a:hover {
+    color: var(--clr-accent-one);
+ }
  
- .progFest-text-grid--performers + .progFest-text-grid--performers{
+ .progFest-text-grid--performers + .progFest-text-grid--performers {
     margin-top: 1.5rem;
  }
 
@@ -1525,7 +1543,6 @@ a {
 }
 
 @media screen and (max-width: 500px) {
-
     .progFest-text-grid {
         grid-template-columns: 1fr;
         gap: 6px;
@@ -1550,7 +1567,6 @@ a {
 @media screen and (max-width: 350px) {
     .progFest-text-grid--performers {
         grid-template-columns: 1fr;
-        gap: 16px;
      }
 
      .progFest-text-grid--performers h5 {

--- a/styles/mainStyles.css
+++ b/styles/mainStyles.css
@@ -1453,11 +1453,11 @@ a {
  }
  
  .progFest-text-grid--performers + .progFest-text-grid--performers {
-    margin-top: 1.5rem;
+    margin-top: 1rem;
  }
 
  .progFest-text-grid + .progFest-text-grid {
-    margin-top: 1rem;
+    margin-top: 0.5rem;
  }
 
  .progFest-text-grid--performers h5 {
@@ -1524,6 +1524,13 @@ a {
         grid-template-columns: 1fr;
         gap: 6px;
      }
+
+     .progFest-text-grid--performers p {
+        /* color: var(--clr-text-100); */
+        color: var(--clr-text-300);
+        font-size: 0.9rem;
+        
+     }
 }
 
 @media (max-width: 768px) {
@@ -1548,8 +1555,20 @@ a {
         gap: 6px;
      }
 
+     .progFest-details-container {
+        margin-top: 0.8rem;
+     }
+
      .progFest-text-grid {
         position: relative;
+     }
+
+     .progFest-text-grid p {
+        font-size: 0.9rem;
+     }
+
+     .progFest-text-grid:not(:last-child) {
+        padding-bottom: 0.5rem;
      }
 
      .progFest-text-grid:not(:last-child)::after {


### PR DESCRIPTION
Updated the home page for ProgFest 2025, including poster, info, times and band spotlight.